### PR TITLE
Harden cleanup against cache thrashing by crawlers

### DIFF
--- a/cleanup-service/cleanup.sh
+++ b/cleanup-service/cleanup.sh
@@ -13,7 +13,7 @@ while [ $counter -lt 100 ]; do
     break
   else
     echo "Cleaning up the least recently accessed directory..."
-    ls -1turF "/var/lib/orbitar_media_data" | grep "/$" | sed 's/\/$//' | grep -v '^coub_cache$' | head -n 100 | xargs -I {} rm -rf "/var/lib/orbitar_media_data/{}"
+    ls -1trF "/var/lib/orbitar_media_data" | grep "/$" | sed 's/\/$//' | grep -v '^coub_cache$' | head -n 100 | xargs -I {} rm -rf "/var/lib/orbitar_media_data/{}"
 
   fi
 

--- a/cleanup-service/cronfile
+++ b/cleanup-service/cronfile
@@ -1,1 +1,1 @@
-0 * * * * (echo "=== $(date) ===" && /usr/local/bin/cleanup.sh) >> /var/log/cron.log 2>&1
+*/15 * * * * (echo "=== $(date) ===" && /usr/local/bin/cleanup.sh) >> /var/log/cron.log 2>&1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       context: cleanup-service
     restart: unless-stopped
     environment:
-      REQUIRED_SPACE: ${REQUIRED_SPACE:-5}
+      REQUIRED_SPACE: ${REQUIRED_SPACE:-10}
     volumes:
       - pictshare_data:/var/lib/orbitar_media_data
 


### PR DESCRIPTION
## Summary
- Sort eviction by **mtime** instead of atime — crawlers reading all files can no longer defeat the eviction order (hash-named dirs have immutable mtime)
- Run cleanup every **15 minutes** instead of hourly for faster recovery when disk fills
- Increase default free space buffer from **5GB to 10GB**

## Context
A crawler was systematically downloading all ~100k files through CloudFront (legacy CDN), filling the 148GB origin disk to 100% and breaking uploads. The atime-based LRU eviction was defeated because the crawl touched every file, updating all access times. Switching to mtime makes eviction crawl-proof since file content (and thus mtime) never changes after creation.

## Test plan
- [x] Dry-run verified on production: `ls -1trF` produces correct eviction order
- [ ] Deploy and monitor disk usage over next 24h
- [ ] Verify cleanup runs every 15 min in container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)